### PR TITLE
Breakup long runs of color

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -751,7 +751,14 @@
       }, 10)
 
     },
-    
+
+    randomSeed: 1,
+
+    pseudoRandom: function(randomSeed) {
+      this.randomSeed = (this.randomSeed*9301 + 49297) % 233280;
+      return this.randomSeed / 233280;
+    },
+
     getLongestBrick: function(xStart, y){
       var color = this.colorGrid[xStart][y].toString(), 
           x, i=0, bar=0;
@@ -765,6 +772,9 @@
           var part_availability_for_color_and_length = window.partNumbers[color_name + "-" + i];
           if(part_availability_for_color_and_length && part_availability_for_color_and_length[2] != "") {
             bar = i;
+            if(app.breakUpLongRuns && this.pseudoRandom() > 0.9) {
+              break;
+            }
           }
         }else{
           break;
@@ -979,6 +989,7 @@ $(function() {
 		this.isoRenderer = new IsoRenderer('#iso', '/images/bricks.png', false, this.brickifier);
 		this.url = null;
 		this.drawing_scale = "large";
+		this.breakUpLongRuns = false;
 		this.isoDirty = false;
 		this.isoRendered = false;
 		
@@ -995,6 +1006,7 @@ $(function() {
 		};
 
 		this.processParams = function(params) {
+		  this.breakUpLongRuns = params["breakUpLongRuns"] == "true" ? true : false;
 			this.drawing_scale = params["scale"];
 			$("#original-url").html(params["url"]);
 			this.updateData(encodeURIComponent(params["url"]), params["updates"]);
@@ -1027,6 +1039,7 @@ $(function() {
 			if (this.url) {
 				url += "?url=" + this.url;
 				url += "&scale=" + this.drawing_scale;
+				url += "&breakUpLongRuns=" + this.breakUpLongRuns;
 
 				if (this.brickifier.updatedBlocks) {
 					url += "&updates=" + encodeURIComponent(this.brickifier.encodeUpdates());
@@ -1043,6 +1056,7 @@ $(function() {
 		this.get("#/", function() {
 			this.app.url = "";
 			this.app.drawing_scale = "large";
+			this.app.breakUpLongRuns = false;
 			this.app.isoDirty = true;
 			this.app.isoRendered = false;
 			this.app.brickifier.updatedBlcoks = null;

--- a/views/app.haml
+++ b/views/app.haml
@@ -20,7 +20,7 @@
     %form#config{:action=>"#/view/", :method=>"get"}
       %h2 Brickify turns your images into bricked out <em>awesome</em>.
       %ul
-        %li
+        %li.config_item
           %label{:for => 'url'}
             %strong Image URL
           %ul
@@ -28,7 +28,8 @@
               %input#url{:type => 'text', :name => "url", :placeholder => "http://"}
             %li
               %a#upload{:href=>'http://imgur.com/'} Need to upload your photo? Use this service
-        %li
+
+        %li.config_item
           %ul
             %li
               Scale:
@@ -41,6 +42,10 @@
             %li
               %input{:type => "radio", :name => "scale", :value => "large", :checked => true}
                 Large
+
+        %li.config_item
+          %input{:type => "checkbox", :name => "breakUpLongRuns", :value => "true", :checked => false}
+            Break up long runs
 
         %li
           %input{:type => 'submit', :value => "Brickify!"}

--- a/views/sass/main.sass
+++ b/views/sass/main.sass
@@ -88,11 +88,14 @@ hr
 #config
   float: left
   width: 510px
-  
+
+  li.config_item
+    margin: 12px auto 0 auto
+
   input
     font:
       family: "Proxima Nova", arial, "sans-serif"
-      
+
     &[type=submit]
       font:
         size: 28px


### PR DESCRIPTION
In some designs with areas of solid backgrounds you can end up with long runs of colors. This is a problem at the top and bottom of some designs as it doesn't provide much rigidity. This patch uses a consistently seeded pseudo random number generator to provide variation in brick-run-lenths but ensures that if you reload the design it is the SAME brick runs are used.
